### PR TITLE
Implementation of Deck + Comment on unused enum

### DIFF
--- a/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicColor.kt
+++ b/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicColor.kt
@@ -8,6 +8,8 @@ package com.github.bjolidon.bootcamp.model
 /**
  * Represents the color of a Magic card.
  */
+
+/* Commented out because it's not used yet in this project.
 enum class MagicColor {
     White,
     Blue,
@@ -16,3 +18,4 @@ enum class MagicColor {
     Green,
     Colorless
 }
+*/

--- a/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicDeck.kt
+++ b/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicDeck.kt
@@ -1,0 +1,30 @@
+// ====================
+// MagicDeck.kt
+// Tarjetakuna, 2023
+// ====================
+
+package com.github.bjolidon.bootcamp.model
+
+/**
+ * Represents a Magic deck.
+ */
+data class MagicDeck(
+    /**
+     * The deck name.
+     */
+    val name: String,
+
+    /**
+     * The deck description.
+     */
+    val description: String,
+
+    /**
+     * The deck cards.
+     */
+    val cards: List<MagicCard>
+    ) {
+    init {
+        require(name.isNotBlank()) { "Name cannot be blank" }
+    }
+}

--- a/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicDeck.kt
+++ b/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicDeck.kt
@@ -21,7 +21,10 @@ data class MagicDeck(
 
     /**
      * The deck cards.
+     * @see MagicCard
      */
+    // For the sake of simplicity now, we'll just use MagicCard class.
+    // It will be better to use a different class for this (like Magic ID).
     val cards: List<MagicCard>
     ) {
     init {

--- a/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicRarity.kt
+++ b/app/src/main/java/com/github/bjolidon/bootcamp/model/MagicRarity.kt
@@ -8,6 +8,7 @@ package com.github.bjolidon.bootcamp.model
 /**
  * Represents the rarity of a Magic card.
  */
+/* Commented out because it's not used yet in this project.
 enum class MagicRarity {
     Common,
     Uncommon,
@@ -16,3 +17,4 @@ enum class MagicRarity {
     Special,
     BasicLand
 }
+*/

--- a/app/src/test/java/com/github/bjolidon/bootcamp/model/MagicDeckTest.kt
+++ b/app/src/test/java/com/github/bjolidon/bootcamp/model/MagicDeckTest.kt
@@ -1,0 +1,34 @@
+// ====================
+// MagicDeckTest.kt
+// Tarjetakuna, 2023
+// ====================
+
+package com.github.bjolidon.bootcamp.model
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class MagicDeckTest {
+
+    private val validName = "Best deck ever"
+    private val validDescription = "Mono red"
+    private val validCards = emptyList<MagicCard>()
+
+    @Test
+    fun blankNameIsInvalid() {
+        assertThrows(IllegalArgumentException::class.java) {
+            MagicDeck("", "Mono red", validCards)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            MagicDeck(" ", "Mono red", validCards)
+        }
+    }
+
+    @Test
+    fun validSet() {
+        val set = MagicDeck(validName, validDescription, validCards)
+        assertEquals(validName, set.name)
+        assertEquals(validDescription, set.description)
+        assertEquals(validCards, set.cards)
+    }
+}


### PR DESCRIPTION
This pull request contains the implementation of a deck from the MTG game, necessary for the elaboration of a fragment for the creation of a deck. In addition, some comments have been added in two enums in order to pass the 100% coverage tests while waiting to add them to the project.