### PR TITLE
activate database field added

### DIFF
--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/SignOutFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/SignOutFragmentTest.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.utils.FBEmulator
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -38,6 +39,7 @@ class SignOutFragmentTest {
 
     @Before
     fun setUp() {
+        DatabaseSync.activateSync = false
         activityRule.scenario.onActivity { activity ->
             activity.changeFragment(R.id.nav_sign_out)
         }

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/database/DatabaseSyncTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/database/DatabaseSyncTest.kt
@@ -36,7 +36,7 @@ class DatabaseSyncTest {
         Mockito.`when`(mockedAuth.isUserLoggedIn()).thenReturn(true)
         Mockito.`when`(mockedAuth.getUserUID()).thenReturn("test")
         SignIn.setSignIn(mockedAuth)
-
+        DatabaseSync.activateSync = true
         LocalDatabaseProvider.setDatabase(
             ApplicationProvider.getApplicationContext(),
             LocalDatabaseProvider.CARDS_DATABASE_NAME,

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/extra/ExportCollectionTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/extra/ExportCollectionTest.kt
@@ -22,6 +22,7 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.GrantPermissionRule
 import com.github.sdp.tarjetakuna.MainActivity
 import com.github.sdp.tarjetakuna.R
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.mockdata.CommonMagicCard
 import com.github.sdp.tarjetakuna.utils.FBEmulator
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
@@ -59,6 +60,7 @@ class ExportCollectionTest {
     @Before
     fun setUp() {
         Intents.init()
+        DatabaseSync.activateSync = false
         activityScenarioRule.scenario.onActivity {
             view = it.findViewById(R.id.nav_home)
         }

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/extra/LocationTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/extra/LocationTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.sdp.tarjetakuna.MainActivity
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.database.FirebaseDB
 import com.github.sdp.tarjetakuna.database.UserRTDB
 import com.github.sdp.tarjetakuna.model.Coordinates
@@ -42,6 +43,7 @@ class LocationTest {
 
     @Before
     fun setUp() {
+        DatabaseSync.activateSync = false
         locationManagerMock = mock(LocationManager::class.java)
         setLocationTo(1.0, 2.0)
         Location.setLastPushedToFirebase(0L)

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/HomeFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/HomeFragmentTest.kt
@@ -14,6 +14,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.github.sdp.tarjetakuna.MainActivity
 import com.github.sdp.tarjetakuna.R
 import com.github.sdp.tarjetakuna.database.DBMagicCard
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.database.local.LocalDatabaseProvider
 import com.github.sdp.tarjetakuna.ui.authentication.Authenticator
 import com.github.sdp.tarjetakuna.ui.authentication.SignIn
@@ -46,6 +47,7 @@ class HomeFragmentTest {
 
     @Before
     fun setUp() {
+        DatabaseSync.activateSync = false
         // mock the authentication
         val mockedAuth = Mockito.mock(Authenticator::class.java)
         Mockito.`when`(mockedAuth.isUserLoggedIn()).thenReturn(true)

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/ProfileFragmentInActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/ProfileFragmentInActivityTest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.sdp.tarjetakuna.MainActivity
 import com.github.sdp.tarjetakuna.R
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.utils.FBEmulator
 import com.github.sdp.tarjetakuna.utils.SharedPreferencesKeys
 import junit.framework.TestCase.assertEquals
@@ -41,6 +42,7 @@ class ProfileFragmentInActivityTest {
 
     @Before
     fun setUp() {
+        DatabaseSync.activateSync = false
         activityRule = ActivityScenario.launch(MainActivity::class.java)
     }
 

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/SingleCardFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/SingleCardFragmentTest.kt
@@ -13,11 +13,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.bumptech.glide.Glide
 import com.github.sdp.tarjetakuna.R
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.database.FirebaseDB
 import com.github.sdp.tarjetakuna.mockdata.CommonFirebase
+import com.github.sdp.tarjetakuna.mockdata.CommonMagicCard
 import com.github.sdp.tarjetakuna.model.*
 import com.github.sdp.tarjetakuna.ui.singlecard.SingleCardFragment
-import com.github.sdp.tarjetakuna.mockdata.CommonMagicCard
 import com.github.sdp.tarjetakuna.utils.CustomGlide
 import com.github.sdp.tarjetakuna.utils.FBEmulator
 import com.github.sdp.tarjetakuna.utils.WithDrawableSafeMatcher
@@ -63,6 +64,7 @@ class SingleCardFragmentTest {
 
     @Before
     fun setup() {
+        DatabaseSync.activateSync = false
         FirebaseDB().returnDatabaseReference().updateChildren(CommonFirebase.goodFirebase)
         IdlingRegistry.getInstance().register(CustomGlide.countingIdlingResource)
     }
@@ -230,7 +232,8 @@ class SingleCardFragmentTest {
      */
     @Test
     fun testTypeTextWorkCorrectlyWithArtifactNoSubtype() {
-        val anotherValidMagicCard = validMagicCard.copy(type = MagicCardType.ARTIFACT, subtypes = listOf())
+        val anotherValidMagicCard =
+            validMagicCard.copy(type = MagicCardType.ARTIFACT, subtypes = listOf())
         val anotherValidJson = Gson().toJson(anotherValidMagicCard)
         val bundleArgs = Bundle().apply { putString("card", anotherValidJson) }
         scenario = launchFragmentInContainer(fragmentArgs = bundleArgs)
@@ -275,7 +278,11 @@ class SingleCardFragmentTest {
         onView(withText(R.string.single_card_users_have)).check(matches(isDisplayed()))
         onView(withText(R.string.single_card_users_want)).check(matches(isDisplayed()))
         onView(withText(R.string.single_card_users_have)).perform(click())
-        onView(withIndex(withText(CommonFirebase.GoodFirebaseAttributes.email1), 0)).check(matches(isDisplayed()))
+        onView(withIndex(withText(CommonFirebase.GoodFirebaseAttributes.email1), 0)).check(
+            matches(
+                isDisplayed()
+            )
+        )
         onView(withIndex(withId(R.id.user_adapter_km_text), 0)).check(matches(isDisplayed()))
         onView(withIndex(withId(R.id.user_adapter_message_button), 0)).check(matches(isDisplayed()))
         onView(withIndex(withId(R.id.user_adapter_profile_button), 0))

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/SingleCardManageCollectionTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/SingleCardManageCollectionTest.kt
@@ -63,7 +63,6 @@ class SingleCardManageCollectionTest {
     @Before
     fun setUp() {
         Intents.init()
-
         // mock the authentication
         val mockedAuth = Mockito.mock(Authenticator::class.java)
         Mockito.`when`(mockedAuth.isUserLoggedIn()).thenReturn(true)

--- a/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/browser/BrowserFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdp/tarjetakuna/ui/browser/BrowserFragmentTest.kt
@@ -15,6 +15,7 @@ import com.github.sdp.tarjetakuna.MainActivity
 import com.github.sdp.tarjetakuna.R
 import com.github.sdp.tarjetakuna.database.CardPossession
 import com.github.sdp.tarjetakuna.database.DBMagicCard
+import com.github.sdp.tarjetakuna.database.DatabaseSync
 import com.github.sdp.tarjetakuna.database.local.LocalDatabaseProvider
 import com.github.sdp.tarjetakuna.mockdata.CommonMagicCard
 import com.github.sdp.tarjetakuna.ui.authentication.Authenticator
@@ -43,7 +44,7 @@ class BrowserFragmentTest {
     @Before
     fun setUp() {
         activityRule = ActivityScenario.launch(MainActivity::class.java)
-
+        DatabaseSync.activateSync = false
         Intents.init()
 
         // mock the authentication

--- a/app/src/main/java/com/github/sdp/tarjetakuna/database/DatabaseSync.kt
+++ b/app/src/main/java/com/github/sdp/tarjetakuna/database/DatabaseSync.kt
@@ -17,6 +17,8 @@ object DatabaseSync {
 
     private var isDoingSync: CompletableFuture<Boolean>? = null
 
+    var activateSync = true
+
     /**
      * Sync the local database with the remote database.
      */
@@ -24,6 +26,12 @@ object DatabaseSync {
     fun sync(): CompletableFuture<Boolean> {
         val isSyncCompleted = CompletableFuture<Boolean>()
         val userRTDB = UserRTDB(FirebaseDB())
+        if (!activateSync) {
+            Log.i("DatabaseSync", "sync: Sync is not activated")
+            isSyncCompleted.completeExceptionally(Exception("Sync is not activated"))
+            return isSyncCompleted
+        }
+
         if (!SignIn.getSignIn().isUserLoggedIn() || LocalDatabaseProvider.getDatabase(
                 LocalDatabaseProvider.CARDS_DATABASE_NAME
             ) == null


### PR DESCRIPTION
activate database sync field to ensure that the sync are not used during the tests as they are not necessary and they make the tests fail for the team, because the test closes the database before the sync is completed